### PR TITLE
Fix MaxMind download links

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM lambci/lambda:build-python3.6
 
+ARG MAXMIND_LICENSE_KEY
 ENV LIBMAXMINDDB_VERSION=1.3.2
 
 # Compilation work for libmaxminddb
@@ -24,9 +25,9 @@ RUN pip install --target=/opt/python/ geoip2
 # Download the DBs!
 RUN mkdir /opt/maxminddb
 WORKDIR /opt/maxminddb
-RUN curl http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz | tar xz
-RUN curl http://geolite.maxmind.com/download/geoip/database/GeoLite2-Country.tar.gz | tar xz
-RUN curl http://geolite.maxmind.com/download/geoip/database/GeoLite2-ASN.tar.gz | tar xz
+RUN curl -L "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=${MAXMIND_LICENSE_KEY}&suffix=tar.gz" | tar xz
+RUN curl -L "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country&license_key=${MAXMIND_LICENSE_KEY}&suffix=tar.gz" | tar xz
+RUN curl -L "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-ASN&license_key=${MAXMIND_LICENSE_KEY}&suffix=tar.gz" | tar xz
 RUN mv */*.mmdb . && rm -r GeoLite2-{ASN,City,Country}_*/
 
 # set workdir back

--- a/README.md
+++ b/README.md
@@ -3,8 +3,31 @@ This is the source project for an AWS Lambda Layer that contains [MaxMind](https
 free GeoLite2 geo IP databases and the C library for reading them and python3.6 build of the
 library against it.
 
-## Deploy
+## Register for a Maxmind license key
+
+Prior to 2019 the GeoIPLite2 databases were available to download without registration.
+Since then you are now required to register a free account to download the databases.
+
+Once you've signed up, login in to their user dashboard and select:
+> Services -> My License Key -> Generate new license key
+
+You may additionally need to navigate to the `GeoLite2` section and approve any legal terms and conditions to get access to the databases.
+
+Once you've done that you should be able to see the `GeoIP2 / GeoLite2 -> Download Files` page.
+
+see: https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases/
+
+## Build
+```bash
+export MAXMIND_LICENSE_KEY='xxxxxxxxx'
 ```
+
+```bash
+./build
+```
+
+## Deploy
+```bash
 sls deploy
 ```
 

--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,20 @@
-#!/bin/bash -x
+#!/bin/bash -ex
 
-set -e
+# Set your license key ENV var before continuing!
+# Check license key is correctly set
+if [ -z "${MAXMIND_LICENSE_KEY}" ]; then
+  set +x
+  2>&1 echo '--------------------------------------------'
+  2>&1 echo 'You must set the env var MAXMIND_LICENSE_KEY'
+  2>&1 echo 'Get your license key from maxmind.com'
+  2>&1 echo 'login -> services -> my license key -> new'
+  2>&1 echo 'note: can take 5 minutes to become active'
+  2>&1 echo '--------------------------------------------'
+  exit 1
+fi
 
 rm -rf layer
-docker build -t geoip-lambda-layer .
+docker build --build-arg MAXMIND_LICENSE_KEY -t geoip-lambda-layer .
 CONTAINER=$(docker run -d geoip-lambda-layer false)
 docker cp $CONTAINER:/opt layer
 docker rm $CONTAINER


### PR DESCRIPTION
MaxMind now requires users to register before downloading GeoLite2 databases  `¯\_(ツ)_/¯`

resolves https://github.com/dschep/geoip-lambda-layer/issues/1
see https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases/